### PR TITLE
Fix keychain reset usage

### DIFF
--- a/NextChapter/src/services/security/keychain.ts
+++ b/NextChapter/src/services/security/keychain.ts
@@ -70,7 +70,7 @@ export class KeychainService {
    */
   async removeSecureValue(key: string): Promise<void> {
     try {
-      await Keychain.resetInternetCredentials({ server: this.serviceName });
+      await Keychain.resetInternetCredentials(this.serviceName);
     } catch (error) {
       throw new Error(`Failed to remove secure value for key: ${key}`);
     }
@@ -132,6 +132,6 @@ export class KeychainService {
    * Clear all values from secure storage
    */
   async clearAllSecureValues(): Promise<void> {
-    await Keychain.resetInternetCredentials({ server: this.serviceName });
+    await Keychain.resetInternetCredentials(this.serviceName);
   }
 }


### PR DESCRIPTION
## Summary
- fix keychain reset parameters to pass service name string

## Testing
- `npm test -- src/services/security/__tests__/keychain.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6879502777148331b7eba2081cff1390